### PR TITLE
Add limiter and HP dc blocking to output

### DIFF
--- a/dsp/HardLimiter.h
+++ b/dsp/HardLimiter.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020 Dave French <contact/dot/dave/dot/french3/at/googlemail/dot/com>
+ *
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#pragma once
+
+#include <cmath>
+#include <utility>
+#include <algorithm>
+
+namespace sspo
+{
+    ///
+    /// !A fixed parameter limiter 
+    /// Based on description given in Prikle, Designing Audio Effects 2nd
+    ///
+    struct Limiter 
+    {
+        Limiter() = default;
+
+        void calcCoeffs()
+        {
+            attackCoeff = std::exp (TC / (sampleRate * attackTime));
+            releaseCoeff = std::exp (TC / (sampleRate * releaseTimes));
+        }
+
+        void setSampleRate(const float sr)
+        {
+            sampleRate = sr;
+            calcCoeffs();
+        }
+
+        void setTimes(const float attack, const float release)
+        {
+            attackTime = attack;
+            releaseTimes = release;
+            calcCoeffs();
+        }
+
+        float process(const float in)
+        {
+            //envelope follower
+            auto rectIn = std::abs (in);
+            currentEnv = rectIn > lastEnv 
+                ? attackCoeff * (lastEnv - rectIn) + rectIn
+                : releaseCoeff * (lastEnv - rectIn) + rectIn;
+            currentEnv = std::max (currentEnv, 0.00000000001f);
+            lastEnv = currentEnv;
+
+            auto dn = 20.0f * std::log10 (currentEnv);
+
+            //Hard knee compression
+            auto yndB = dn <= threshold ? dn : threshold + ((dn - threshold) / ratio);
+            auto gndB = yndB - dn;
+            auto G = std::pow (10.0f, gndB / 20);
+
+            return in * G;
+        }
+        
+        float attackTime{ 0.0001f };
+        float releaseTimes{ 0.0025f };
+        float ratio{ 10.5f };
+        float threshold{ -0.0f }; //dB
+
+        private:
+
+        float attackCoeff{ 0.0f };
+        float releaseCoeff{ 0.0f };
+        float lastEnv{ 0.0f };
+        float currentEnv{ 0.0f };
+        float sampleRate{ 1.0f };
+
+        static constexpr float TC{ -0.9996723408f }; // { std::log (0.368f); } //capacitor discharge to 36.8%
+    };
+}


### PR DESCRIPTION
Added a limiter to the feedback loop, to stop noise being generated when the input signal and the buffer frequency are the same or integer multiple.

Added dc blocking filter to the output.

fixes #7 