### PR TITLE
3hp 8 channel mixer with attenuverter

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -51,6 +51,15 @@
         "Polyphonic",
         "Filter"
       ]
+    },
+    {
+      "slug": "Mix",
+      "name": "Mix",
+      "description": "Mixer",
+      "tags": [
+        "Polyphonic",
+        "Mixer"
+      ]
     }
   ]
 }

--- a/res/Mix.svg
+++ b/res/Mix.svg
@@ -1,0 +1,414 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="100.2962"
+   inkscape:export-xdpi="100.2962"
+   inkscape:export-filename="/home/curlymorphic/dev/VCVModuleIdeas/res/mix.png"
+   inkscape:version="1.0 (5b275a35d9, 2020-05-03)"
+   sodipodi:docname="Mix.svg"
+   id="svg4541"
+   version="1.1"
+   viewBox="0 0 15.24 128.50002"
+   height="128.5mm"
+   width="15.24mm">
+  <title
+     id="title4354">SSPO 3HP template</title>
+  <defs
+     id="defs4535">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1761">
+      <stop
+         id="stop1759"
+         offset="0"
+         style="stop-color:#ffff00;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1755">
+      <stop
+         id="stop1753"
+         offset="0"
+         style="stop-color:#0000ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1749">
+      <stop
+         id="stop1747"
+         offset="0"
+         style="stop-color:#00ff00;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1743">
+      <stop
+         id="stop1741"
+         offset="0"
+         style="stop-color:#ff0000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1737">
+      <stop
+         id="stop1735"
+         offset="0"
+         style="stop-color:#ff00ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient1686">
+      <stop
+         id="stop1684"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5500">
+      <stop
+         id="stop5498"
+         offset="0"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5494">
+      <stop
+         id="stop5492"
+         offset="0"
+         style="stop-color:#cdde87;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.27602379,0,0,0.27602379,258.97098,49.777249)"
+       gradientUnits="userSpaceOnUse"
+       y2="444.60522"
+       x2="-867.84308"
+       y1="444.60522"
+       x1="-906.18518"
+       id="linearGradient5496"
+       xlink:href="#linearGradient5494"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.05150635,0,0,0.27616015,57.827317,53.733312)"
+       gradientUnits="userSpaceOnUse"
+       y2="269.14816"
+       x2="-697.97778"
+       y1="269.14816"
+       x1="-993.65643"
+       id="linearGradient5502"
+       xlink:href="#linearGradient5500"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="55.57832"
+       x2="-831.97699"
+       y1="55.57832"
+       x1="-869.41425"
+       gradientTransform="matrix(0.27602379,0,0,0.27602379,249.79256,54.572287)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7320"
+       xlink:href="#linearGradient1686"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:snap-others="false"
+     inkscape:snap-nodes="false"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:document-rotation="0"
+     showborder="true"
+     inkscape:snap-global="false"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox="true"
+     units="mm"
+     inkscape:window-maximized="1"
+     inkscape:window-y="27"
+     inkscape:window-x="0"
+     inkscape:window-height="948"
+     inkscape:window-width="1920"
+     fit-margin-bottom="0"
+     fit-margin-right="0"
+     fit-margin-left="0"
+     fit-margin-top="0"
+     showgrid="true"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="217.70701"
+     inkscape:cx="-48.626958"
+     inkscape:zoom="1"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base"
+     inkscape:snap-bbox-midpoints="true">
+    <inkscape:grid
+       spacingx="1.5240002"
+       units="mm"
+       id="grid5963"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4538">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>SSPO 3HP template</dc:title>
+        <dc:identifier>SSPO 3HP template</dc:identifier>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-6.6477068,-63.816955)"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1"
+     style="display:inline">
+    <path
+       inkscape:export-ydpi="100.2962"
+       inkscape:export-xdpi="100.2962"
+       inkscape:export-filename="/home/vortico/src/cpp/VCV/Rack/plugins/Fundamental/res/Delay.png"
+       inkscape:connector-curvature="0"
+       id="path25061"
+       d="M 6.6477068,63.816955 H 21.877034 V 192.30567 H 6.6477068 Z m 0,0"
+       style="fill:url(#linearGradient5502);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.182863" />
+    <rect
+       y="190.64796"
+       x="6.6477017"
+       height="1.6670943"
+       width="15.237206"
+       id="rect5276"
+       style="fill:#cdde87;fill-opacity:1;stroke-width:0.178723" />
+    <rect
+       style="fill:url(#linearGradient5496);fill-opacity:1;stroke-width:0.321107"
+       id="rect5287"
+       width="10.583327"
+       height="10.535396"
+       x="8.8423147"
+       y="167.23116" />
+    <g
+       aria-label="Studio Six Plus One"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.7807px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.844236"
+       id="text5967-7-1-3"
+       transform="matrix(0,-0.27602379,0.3524041,0,-123.86376,-70.222618)">
+      <path
+         d="m -938.94801,379.11774 q 0,0.32576 -0.15352,0.64403 -0.14977,0.31827 -0.42311,0.53918 -0.29955,0.23964 -0.70019,0.37444 -0.39691,0.13479 -0.95856,0.13479 -0.60284,0 -1.08586,-0.11233 -0.47927,-0.11233 -0.97727,-0.33324 v -0.9286 h 0.0524 q 0.42311,0.35197 0.97727,0.54293 0.55417,0.19096 1.04093,0.19096 0.68896,0 1.07088,-0.25836 0.38567,-0.25836 0.38567,-0.68896 0,-0.37069 -0.18347,-0.54667 -0.17973,-0.17599 -0.55042,-0.27334 -0.28083,-0.0749 -0.61033,-0.12356 -0.32576,-0.0487 -0.6927,-0.12357 -0.74138,-0.15726 -1.10084,-0.53544 -0.35571,-0.38192 -0.35571,-0.99225 0,-0.70019 0.5916,-1.14577 0.59161,-0.44932 1.50149,-0.44932 0.58786,0 1.07837,0.11233 0.49051,0.11233 0.86869,0.27708 v 0.87618 h -0.0524 q -0.31827,-0.2696 -0.83874,-0.44558 -0.51672,-0.17973 -1.05965,-0.17973 -0.59535,0 -0.95855,0.24713 -0.35946,0.24712 -0.35946,0.63654 0,0.34822 0.17973,0.54667 0.17973,0.19845 0.6328,0.30329 0.23963,0.0524 0.68147,0.12731 0.44183,0.0749 0.74887,0.15352 0.62156,0.16475 0.93608,0.498 0.31453,0.33324 0.31453,0.93234 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6170"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -935.64175,380.67164 q -0.19845,0.0524 -0.43435,0.0861 -0.23215,0.0337 -0.41562,0.0337 -0.64028,0 -0.97353,-0.34448 -0.33325,-0.34448 -0.33325,-1.10458 v -2.22414 h -0.47553 v -0.59161 h 0.47553 v -1.20193 h 0.70394 v 1.20193 h 1.45281 v 0.59161 h -1.45281 v 1.90587 q 0,0.3295 0.015,0.51672 0.015,0.18347 0.10484,0.34448 0.0824,0.14977 0.22466,0.22092 0.14603,0.0674 0.44183,0.0674 0.17224,0 0.35946,-0.0487 0.18722,-0.0524 0.26959,-0.0861 h 0.0375 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6172"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -931.32078,380.70909 h -0.70394 v -0.4643 q -0.35571,0.28082 -0.68147,0.4306 -0.32575,0.14977 -0.71891,0.14977 -0.65901,0 -1.02595,-0.40064 -0.36695,-0.40439 -0.36695,-1.18322 v -2.71465 h 0.70394 v 2.38141 q 0,0.31826 0.0299,0.54667 0.03,0.22466 0.12731,0.38567 0.1011,0.16475 0.26211,0.23964 0.161,0.0749 0.46804,0.0749 0.27334,0 0.59535,-0.14228 0.32576,-0.14229 0.60658,-0.3632 v -3.12279 h 0.70394 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6174"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -926.54299,380.70909 h -0.70394 V 380.271 q -0.30329,0.2621 -0.63279,0.40813 -0.32951,0.14603 -0.71517,0.14603 -0.74887,0 -1.19071,-0.57663 -0.43809,-0.57663 -0.43809,-1.59883 0,-0.5317 0.14978,-0.94732 0.15352,-0.41563 0.41188,-0.70769 0.25461,-0.28457 0.5916,-0.43434 0.34074,-0.14977 0.70394,-0.14977 0.3295,0 0.58412,0.0711 0.25461,0.0674 0.53544,0.21343 v -1.81227 h 0.70394 z m -0.70394,-1.0297 v -2.40013 q -0.28457,-0.1273 -0.50923,-0.17598 -0.22466,-0.0487 -0.49051,-0.0487 -0.59161,0 -0.92111,0.41188 -0.3295,0.41188 -0.3295,1.16824 0,0.74512 0.25461,1.13454 0.25462,0.38566 0.81627,0.38566 0.29955,0 0.60658,-0.13105 0.30704,-0.1348 0.57289,-0.34448 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6176"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -924.40123,375.82646 h -0.7938 v -0.73015 h 0.7938 z m -0.0449,4.88263 h -0.70394 v -4.18244 h 0.70394 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6178"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -919.48116,378.61974 q 0,1.02221 -0.5242,1.61381 -0.52421,0.59161 -1.40413,0.59161 -0.88741,0 -1.41162,-0.59161 -0.52047,-0.5916 -0.52047,-1.61381 0,-1.02221 0.52047,-1.61381 0.52421,-0.59535 1.41162,-0.59535 0.87992,0 1.40413,0.59535 0.5242,0.5916 0.5242,1.61381 z m -0.7264,0 q 0,-0.81252 -0.31827,-1.20568 -0.31827,-0.3969 -0.88366,-0.3969 -0.57289,0 -0.89116,0.3969 -0.31452,0.39316 -0.31452,1.20568 0,0.78631 0.31827,1.19445 0.31826,0.40439 0.88741,0.40439 0.56165,0 0.87992,-0.40065 0.32201,-0.40439 0.32201,-1.19819 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6180"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -938.90682,389.6158 q 0,0.32576 -0.15352,0.64403 -0.14977,0.31827 -0.42311,0.53918 -0.29955,0.23964 -0.70019,0.37444 -0.3969,0.13479 -0.95855,0.13479 -0.60284,0 -1.08586,-0.11233 -0.47928,-0.11233 -0.97728,-0.33324 v -0.9286 h 0.0524 q 0.42311,0.35197 0.97728,0.54293 0.55416,0.19096 1.04093,0.19096 0.68895,0 1.07088,-0.25836 0.38567,-0.25836 0.38567,-0.68896 0,-0.37069 -0.18348,-0.54667 -0.17973,-0.17599 -0.55042,-0.27334 -0.28082,-0.0749 -0.61032,-0.12356 -0.32576,-0.0487 -0.69271,-0.12357 -0.74138,-0.15726 -1.10084,-0.53544 -0.35571,-0.38192 -0.35571,-0.99225 0,-0.70019 0.59161,-1.14577 0.5916,-0.44932 1.50148,-0.44932 0.58786,0 1.07837,0.11233 0.49051,0.11233 0.86869,0.27708 v 0.87618 h -0.0524 q -0.31827,-0.2696 -0.83873,-0.44558 -0.51672,-0.17973 -1.05965,-0.17973 -0.59536,0 -0.95856,0.24713 -0.35945,0.24712 -0.35945,0.63654 0,0.34822 0.17972,0.54667 0.17973,0.19845 0.6328,0.30329 0.23964,0.0524 0.68147,0.12731 0.44183,0.0749 0.74887,0.15352 0.62156,0.16475 0.93609,0.498 0.31452,0.33324 0.31452,0.93234 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6182"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -937.01593,386.32452 h -0.7938 v -0.73015 h 0.7938 z m -0.0449,4.88263 h -0.70394 v -4.18244 h 0.70394 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6184"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -932.03969,391.20715 h -0.88741 l -1.18696,-1.60633 -1.19444,1.60633 h -0.82001 l 1.63253,-2.0856 -1.61756,-2.09684 h 0.88741 l 1.17947,1.58012 1.18322,-1.58012 h 0.82375 l -1.64377,2.05939 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6186"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -939.91312,398.65275 q 0,0.37069 -0.13105,0.68896 -0.12731,0.31453 -0.35945,0.54667 -0.28832,0.28832 -0.68148,0.43435 -0.39315,0.14228 -0.99225,0.14228 h -0.74138 v 2.07812 h -0.74138 v -5.57534 h 1.51272 q 0.50174,0 0.84996,0.0861 0.34823,0.0824 0.61782,0.26211 0.31827,0.21343 0.49051,0.5317 0.17598,0.31827 0.17598,0.80503 z m -0.77133,0.0187 q 0,-0.28831 -0.1011,-0.50174 -0.1011,-0.21343 -0.30703,-0.34822 -0.17973,-0.11608 -0.41188,-0.16476 -0.22841,-0.0524 -0.58038,-0.0524 h -0.73389 v 2.22789 h 0.62531 q 0.44932,0 0.73015,-0.0786 0.28082,-0.0824 0.45681,-0.25836 0.17598,-0.17973 0.24712,-0.37818 0.0749,-0.19845 0.0749,-0.44558 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6188"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -938.27683,402.54313 h -0.70394 v -5.82621 h 0.70394 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6190"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -933.40919,402.54313 h -0.70393 v -0.4643 q -0.35572,0.28082 -0.68148,0.4306 -0.32575,0.14977 -0.71891,0.14977 -0.659,0 -1.02595,-0.40064 -0.36695,-0.40439 -0.36695,-1.18322 v -2.71465 h 0.70394 v 2.38141 q 0,0.31826 0.03,0.54667 0.03,0.22466 0.1273,0.38567 0.1011,0.16475 0.26211,0.23964 0.161,0.0749 0.46804,0.0749 0.27334,0 0.59535,-0.14228 0.32576,-0.14229 0.60659,-0.3632 v -3.12279 h 0.70393 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6192"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -929.03579,401.33745 q 0,0.57288 -0.47553,0.93983 -0.47179,0.36694 -1.2918,0.36694 -0.4643,0 -0.85371,-0.10858 -0.38567,-0.11233 -0.64778,-0.24339 v -0.79005 h 0.0374 q 0.33325,0.25087 0.74138,0.40064 0.40813,0.14603 0.78257,0.14603 0.4643,0 0.7264,-0.14977 0.2621,-0.14978 0.2621,-0.47179 0,-0.24713 -0.14228,-0.37443 -0.14229,-0.12731 -0.54668,-0.21718 -0.14977,-0.0337 -0.39315,-0.0786 -0.23964,-0.0449 -0.43809,-0.0974 -0.55042,-0.14603 -0.78257,-0.42686 -0.2284,-0.28457 -0.2284,-0.69644 0,-0.25836 0.10484,-0.48677 0.10858,-0.2284 0.32576,-0.40813 0.20968,-0.17599 0.53169,-0.27708 0.32576,-0.10485 0.72641,-0.10485 0.37443,0 0.75635,0.0936 0.38567,0.0899 0.64029,0.22092 v 0.75261 h -0.0375 q -0.26959,-0.19845 -0.65526,-0.33324 -0.38566,-0.13855 -0.75635,-0.13855 -0.38567,0 -0.65152,0.14978 -0.26585,0.14603 -0.26585,0.43809 0,0.25836 0.16101,0.38941 0.15726,0.13105 0.50923,0.21343 0.19471,0.0449 0.43434,0.0899 0.24339,0.0449 0.40439,0.0824 0.49051,0.11233 0.75636,0.38566 0.26585,0.27709 0.26585,0.7339 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6194"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -939.25612,406.73596 q 0.34074,0.37443 0.52047,0.91736 0.18347,0.54293 0.18347,1.23189 0,0.68896 -0.18722,1.23564 -0.18347,0.54293 -0.51672,0.90613 -0.34448,0.37818 -0.81626,0.56914 -0.46805,0.19096 -1.07089,0.19096 -0.58786,0 -1.07088,-0.19471 -0.47928,-0.1947 -0.81627,-0.56539 -0.33699,-0.37069 -0.52046,-0.90988 -0.17973,-0.53918 -0.17973,-1.23189 0,-0.68147 0.17973,-1.22065 0.17973,-0.54293 0.52421,-0.9286 0.3295,-0.36695 0.81626,-0.56165 0.49051,-0.19471 1.06714,-0.19471 0.5991,0 1.07463,0.19845 0.47928,0.19471 0.81252,0.55791 z m -0.0674,2.14925 q 0,-1.08586 -0.48677,-1.67372 -0.48676,-0.59161 -1.32924,-0.59161 -0.84997,0 -1.33673,0.59161 -0.48303,0.58786 -0.48303,1.67372 0,1.0971 0.49426,1.68121 0.49425,0.58038 1.3255,0.58038 0.83124,0 1.32175,-0.58038 0.49426,-0.58411 0.49426,-1.68121 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6196"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -933.9354,411.67101 h -0.70394 v -2.38141 q 0,-0.28831 -0.0337,-0.53918 -0.0337,-0.25462 -0.12357,-0.3969 -0.0936,-0.15727 -0.26959,-0.23215 -0.17599,-0.0786 -0.45681,-0.0786 -0.28832,0 -0.60284,0.14229 -0.31453,0.14228 -0.60284,0.3632 v 3.12279 h -0.70394 v -4.18244 h 0.70394 v 0.4643 q 0.3295,-0.27334 0.68147,-0.42686 0.35197,-0.15351 0.72266,-0.15351 0.67773,0 1.03344,0.40813 0.35571,0.40813 0.35571,1.17572 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6198"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -929.07899,409.6528 h -3.08159 q 0,0.38567 0.11607,0.67399 0.11608,0.28457 0.31827,0.46804 0.19471,0.17973 0.46056,0.26959 0.26959,0.0899 0.5916,0.0899 0.42686,0 0.85746,-0.1685 0.43434,-0.17224 0.61782,-0.33699 h 0.0374 v 0.76759 q -0.35571,0.14977 -0.7264,0.25087 -0.37069,0.1011 -0.77883,0.1011 -1.04093,0 -1.62504,-0.56165 -0.58412,-0.5654 -0.58412,-1.60258 0,-1.02595 0.55791,-1.62879 0.56165,-0.60284 1.47527,-0.60284 0.84622,0 1.30303,0.49425 0.46055,0.49425 0.46055,1.40413 z m -0.68521,-0.53918 q -0.004,-0.55417 -0.28083,-0.85746 -0.27333,-0.30329 -0.83499,-0.30329 -0.56539,0 -0.90238,0.33325 -0.33325,0.33324 -0.37818,0.8275 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.66842px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.844236"
+         id="path6200"
+         inkscape:connector-curvature="0" />
+    </g>
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot4937"
+       style="font-style:normal;font-weight:normal;font-size:10.6667px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.88074"
+       transform="matrix(0.26458333,0,0,0.26458333,6.6477061,63.816955)"><flowRegion
+         id="flowRegion4939"><rect
+           id="rect4941"
+           width="31.062191"
+           height="10.859139"
+           x="98.237335"
+           y="242.7276" /></flowRegion><flowPara
+         id="flowPara4943">color</flowPara></flowRoot>
+    <g
+       transform="matrix(0.27602379,0,0,0.27602379,259.40365,49.82163)"
+       aria-label="out"
+       style="font-style:normal;font-weight:normal;font-size:10.2246px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.844236"
+       id="text4973">
+      <path
+         d="m -892.44242,419.37275 q -0.73888,0 -1.16824,0.57913 -0.42935,0.57413 -0.42935,1.57762 0,1.00348 0.42436,1.58261 0.42935,0.57413 1.17323,0.57413 0.73389,0 1.16324,-0.57913 0.42936,-0.57912 0.42936,-1.57761 0,-0.9935 -0.42936,-1.57263 -0.42935,-0.58412 -1.16324,-0.58412 z m 0,-0.77882 q 1.19819,0 1.88216,0.77882 0.68397,0.77883 0.68397,2.15675 0,1.37292 -0.68397,2.15674 -0.68397,0.77882 -1.88216,0.77882 -1.20318,0 -1.88715,-0.77882 -0.67897,-0.78382 -0.67897,-2.15674 0,-1.37792 0.67897,-2.15675 0.68397,-0.77882 1.88715,-0.77882 z"
+         style="stroke-width:0.844236"
+         id="path4975"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -888.45344,422.11361 v -3.38489 h 0.91861 v 3.34995 q 0,0.7938 0.30953,1.1932 0.30954,0.3944 0.9286,0.3944 0.74388,0 1.17323,-0.47428 0.43434,-0.47429 0.43434,-1.29305 v -3.17022 h 0.91862 v 5.59156 h -0.91862 v -0.8587 q -0.33449,0.50923 -0.77882,0.75885 -0.43934,0.24463 -1.02345,0.24463 -0.96355,0 -1.4628,-0.59909 -0.49924,-0.5991 -0.49924,-1.75236 z m 2.31151,-3.51968 z"
+         style="stroke-width:0.844236"
+         id="path4977"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -880.95976,417.14112 v 1.5876 h 1.89215 v 0.71393 h -1.89215 v 3.03541 q 0,0.68397 0.18472,0.87868 0.18972,0.1947 0.76385,0.1947 h 0.94358 v 0.76884 h -0.94358 q -1.06339,0 -1.46778,-0.3944 -0.40439,-0.3994 -0.40439,-1.44782 v -3.03541 h -0.67398 v -0.71393 h 0.67398 v -1.5876 z"
+         style="stroke-width:0.844236"
+         id="path4979"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       style="font-style:normal;font-weight:normal;font-size:2.82223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient7320);fill-opacity:1;stroke:none;stroke-width:0.233029"
+       id="text5506"
+       aria-label="Mix">
+      <path
+         id="path1151"
+         style="font-size:4.93889px;fill:url(#linearGradient7320);fill-opacity:1;stroke-width:0.233029"
+         d="m 10.312738,68.153985 h 0.725881 l 0.918807,2.450153 0.923631,-2.450153 h 0.725882 v 3.600471 H 13.13186 v -3.161565 l -0.928454,2.469445 h -0.489548 l -0.928453,-2.469445 v 3.161565 h -0.472667 z" />
+      <path
+         id="path1153"
+         style="font-size:4.93889px;fill:url(#linearGradient7320);fill-opacity:1;stroke-width:0.233029"
+         d="m 14.557096,69.0535 h 0.443728 v 2.700956 h -0.443728 z m 0,-1.051443 h 0.443728 v 0.561895 h -0.443728 z" />
+      <path
+         id="path1155"
+         style="font-size:4.93889px;fill:url(#linearGradient7320);fill-opacity:1;stroke-width:0.233029"
+         d="m 18.172035,69.0535 -0.976685,1.314304 1.027328,1.386652 h -0.52331 l -0.786171,-1.06109 -0.786171,1.06109 h -0.52331 L 16.652748,70.341277 15.692944,69.0535 h 0.52331 l 0.716236,0.962215 0.716235,-0.962215 z" />
+    </g>
+  </g>
+  <g
+     style="display:none"
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="components">
+    <circle
+       style="display:inline;opacity:1;fill:#00ff00;fill-opacity:1;stroke-width:0.264584"
+       id="path1587-8-2-7"
+       cx="7.6237741"
+       cy="14.361665"
+       r="3.9687526"
+       inkscape:label="ONE" />
+    <circle
+       style="display:inline;opacity:1;fill:#00ff00;fill-opacity:1;stroke-width:0.264584"
+       id="path1587-8-2-5"
+       cx="7.6320968"
+       cy="23.549356"
+       r="3.9687526"
+       inkscape:label="TWO" />
+    <circle
+       style="display:inline;opacity:1;fill:#00ff00;fill-opacity:1;stroke-width:0.264584"
+       id="path1587-8-2-9"
+       cx="7.6144748"
+       cy="32.702019"
+       r="3.9687526"
+       inkscape:label="THREE" />
+    <circle
+       style="display:inline;opacity:1;fill:#00ff00;fill-opacity:1;stroke-width:0.264584"
+       id="path1587-8-2-70"
+       cx="7.6350617"
+       cy="41.903267"
+       r="3.9687526"
+       inkscape:label="FOUR" />
+    <circle
+       style="display:inline;opacity:1;fill:#00ff00;fill-opacity:1;stroke-width:0.264584"
+       id="path1587-8-2-6"
+       cx="7.6148114"
+       cy="51.118504"
+       r="3.9687526"
+       inkscape:label="FIVE" />
+    <circle
+       style="display:inline;opacity:1;fill:#00ff00;fill-opacity:1;stroke-width:0.264584"
+       id="path1587-8-2-2"
+       cx="7.6169343"
+       cy="60.301861"
+       r="3.9687526"
+       inkscape:label="SIX" />
+    <circle
+       style="display:inline;opacity:1;fill:#00ff00;fill-opacity:1;stroke-width:0.264584"
+       id="path1587-8-2-79"
+       cx="7.5869803"
+       cy="69.50219"
+       r="3.9687526"
+       inkscape:label="SEVEN" />
+    <circle
+       style="display:inline;opacity:1;fill:#00ff00;fill-opacity:1;stroke-width:0.264584"
+       id="path1587-8-2-23"
+       cx="7.6029515"
+       cy="78.695312"
+       r="3.9687526"
+       inkscape:label="EIGHT" />
+    <circle
+       style="display:inline;opacity:1;fill:#ff0000;fill-opacity:1;stroke-width:0.264584"
+       id="path1587-8-0-3-9"
+       cx="7.6193938"
+       cy="93.39798"
+       r="3.9687526"
+       inkscape:label="ATTENUVERTER" />
+    <circle
+       style="display:inline;opacity:0.998;fill:#0000ff;fill-opacity:1;stroke-width:0.264584"
+       id="path1389-89"
+       cx="7.6193938"
+       cy="108.47925"
+       r="3.9687526"
+       inkscape:label="MAIN" />
+  </g>
+</svg>

--- a/src/Mix.cpp
+++ b/src/Mix.cpp
@@ -1,0 +1,94 @@
+#include "plugin.hpp"
+using simd::float_4;
+
+
+struct Mix : Module 
+{
+	enum ParamIds 
+	{
+		ATTENUVERTER_PARAM,
+		NUM_PARAMS
+	};
+	enum InputIds 
+	{
+		ONE_INPUT,
+		TWO_INPUT,
+		THREE_INPUT,
+		FOUR_INPUT,
+		FIVE_INPUT,
+		SIX_INPUT,
+		SEVEN_INPUT,
+		EIGHT_INPUT,
+		NUM_INPUTS
+	};
+	enum OutputIds 
+	{
+		MAIN_OUTPUT,
+		NUM_OUTPUTS
+	};
+	enum LightIds 
+	{
+		NUM_LIGHTS
+	};
+
+	Mix() 
+	{
+		config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
+		configParam(ATTENUVERTER_PARAM, -1.0f, 1.0f, 1.0f, "");
+	}
+
+	int maxInputChannels()
+	{
+		auto ret = 0;
+		for (auto i = 0; i < NUM_INPUTS; ++i)
+		{
+			if (inputs[i].getChannels() > ret)
+				ret = inputs[i].getChannels(); 
+		}
+		return ret;
+	}
+
+	void process(const ProcessArgs& args) override 
+	{
+		auto channels = maxInputChannels();
+
+		for (auto c = 0; c < channels; c += 4)
+		{
+			float_4 out {};
+			for (auto i = 0; i < NUM_INPUTS; ++i)
+				out += inputs[i].getPolyVoltageSimd<float_4> (c);
+				
+			out *= params[ATTENUVERTER_PARAM].getValue();
+
+			//set output
+			out.store(outputs[MAIN_OUTPUT].getVoltages(c));
+		}
+
+		outputs[MAIN_OUTPUT].setChannels (channels);
+	}
+};
+
+
+struct MixWidget : ModuleWidget {
+	MixWidget(Mix* module) {
+		setModule(module);
+		setPanel(APP->window->loadSvg(asset::plugin(pluginInstance, "res/Mix.svg")));
+
+
+		addParam(createParamCentered<RoundBlackKnob>(mm2px(Vec(7.619, 93.398)), module, Mix::ATTENUVERTER_PARAM));
+
+		addInput(createInputCentered<PJ301MPort>(mm2px(Vec(7.624, 14.362)), module, Mix::ONE_INPUT));
+		addInput(createInputCentered<PJ301MPort>(mm2px(Vec(7.632, 23.549)), module, Mix::TWO_INPUT));
+		addInput(createInputCentered<PJ301MPort>(mm2px(Vec(7.614, 32.702)), module, Mix::THREE_INPUT));
+		addInput(createInputCentered<PJ301MPort>(mm2px(Vec(7.635, 41.903)), module, Mix::FOUR_INPUT));
+		addInput(createInputCentered<PJ301MPort>(mm2px(Vec(7.615, 51.119)), module, Mix::FIVE_INPUT));
+		addInput(createInputCentered<PJ301MPort>(mm2px(Vec(7.617, 60.302)), module, Mix::SIX_INPUT));
+		addInput(createInputCentered<PJ301MPort>(mm2px(Vec(7.587, 69.502)), module, Mix::SEVEN_INPUT));
+		addInput(createInputCentered<PJ301MPort>(mm2px(Vec(7.603, 78.695)), module, Mix::EIGHT_INPUT));
+
+		addOutput(createOutputCentered<PJ301MPort>(mm2px(Vec(7.619, 108.479)), module, Mix::MAIN_OUTPUT));
+	}
+};
+
+
+Model* modelMix = createModel<Mix, MixWidget>("Mix");

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -12,4 +12,5 @@ void init(::rack::Plugin* p) {
 	p->addModel (modelMaccomo);
 	p->addModel (modelPolyShiftRegister);
 	p->addModel (modelCombFilter);
+	p->addModel (modelMix);
 }

--- a/src/plugin.hpp
+++ b/src/plugin.hpp
@@ -11,3 +11,4 @@ extern Model* modelKSDelay;
 extern Model* modelMaccomo;
 extern Model* modelPolyShiftRegister;
 extern Model* modelCombFilter;
+extern Model* modelMix;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7412852/81213685-a4414f80-8fce-11ea-8ecb-8ea299dde35a.png)
The vcv library has many 3hp 8 channel mixers, none with an attenuverter. I have not had a single instance of such a module without having to insert an attenuverter afterward.

This module is polyphonic, following the VCV guidelines 

The advantages of this module mean less delay to the signal and less onscreen clutter.
- [ ] readme
- [ ] rename

Similar modules:
https://library.vcvrack.com/ML_modules/Sum8
https://library.vcvrack.com/Mental/MentalSums
https://library.vcvrack.com/Bogaudio/Bogaudio-UMix
